### PR TITLE
Handle multiple license keys and validate empty input

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,11 @@
+import importlib
+import sys
+from pathlib import Path
+
+
+def test_empty_key_rejected(monkeypatch):
+    monkeypatch.setenv("APP_PASS", "foo")
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    app = importlib.import_module("app")
+    importlib.reload(app)
+    assert app.check_key("") is False


### PR DESCRIPTION
## Summary
- hash and filter environment license keys, supporting multiple keys
- reject empty or whitespace keys during authentication
- add test ensuring empty key is rejected

## Testing
- `pytest tests/test_app.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c163641c6c832aa94b5362d2acf85c