### PR TITLE
Refactor cost calculations into standalone module

### DIFF
--- a/calc.py
+++ b/calc.py
@@ -1,0 +1,53 @@
+"""Pure calculation utilities for food cost logic."""
+
+from typing import Dict, Tuple, Any
+
+
+def unit_cost(name: str, ingredients: Dict[str, Dict[str, Any]]) -> float:
+    """Compute unit cost for an ingredient from catalog data."""
+    d = ingredients[name]
+    return float(d["package_price"]) / max(float(d["package_qty"]), 1e-9)
+
+
+def to_base(qty: float, unit: str) -> float:
+    """Convert quantity to base unit (kg or L)."""
+    if unit == "g":
+        return qty / 1000.0
+    if unit == "ml":
+        return qty / 1000.0
+    return qty
+
+
+def to_weight_kg(name: str, qty: float, unit: str, densities: Dict[str, float]) -> float:
+    """Convert various units to kilograms using densities when needed."""
+    if unit == "kg":
+        return qty
+    if unit == "g":
+        return qty / 1000.0
+    if unit in ("L", "ml"):
+        dens = densities.get(name)
+        if not dens:
+            return 0.0
+        return dens * qty if unit == "L" else dens * qty / 1000.0
+    return 0.0
+
+
+def batch_total_cost(batch: Dict[str, Any], ingredients: Dict[str, Dict[str, Any]]) -> float:
+    """Compute total batch cost given ingredient catalog."""
+    total = 0.0
+    for it in batch.get("items", []):
+        if it["name"] not in ingredients:
+            continue
+        total += unit_cost(it["name"], ingredients) * to_base(float(it["qty"]), it["unit"])
+    return total
+
+
+def batch_total_weight_kg(batch: Dict[str, Any], densities: Dict[str, float]) -> Tuple[float, int]:
+    """Return total weight in kg and number of items lacking density info."""
+    w, unknown = 0.0, 0
+    for it in batch.get("items", []):
+        wk = to_weight_kg(it["name"], float(it["qty"]), it["unit"], densities)
+        if it["unit"] in ("L", "ml") and wk == 0.0:
+            unknown += 1
+        w += wk
+    return w, unknown

--- a/tests/test_calc.py
+++ b/tests/test_calc.py
@@ -1,0 +1,40 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from calc import unit_cost, batch_total_cost, batch_total_weight_kg
+
+
+def test_unit_cost():
+    ingredients = {"Flour": {"package_price": 25.0, "package_qty": 25}}
+    assert unit_cost("Flour", ingredients) == pytest.approx(1.0)
+
+
+def test_batch_total_cost():
+    ingredients = {
+        "Flour": {"package_price": 2.0, "package_qty": 1},
+        "Water": {"package_price": 1.0, "package_qty": 1},
+    }
+    batch = {
+        "items": [
+            {"name": "Flour", "qty": 1, "unit": "kg"},
+            {"name": "Water", "qty": 500, "unit": "g"},
+        ]
+    }
+    assert batch_total_cost(batch, ingredients) == pytest.approx(2.5)
+
+
+def test_batch_total_weight_kg():
+    densities = {"Water": 1.0}
+    batch = {
+        "items": [
+            {"name": "Flour", "qty": 1, "unit": "kg"},
+            {"name": "Water", "qty": 500, "unit": "ml"},
+            {"name": "Oil", "qty": 100, "unit": "ml"},
+        ]
+    }
+    total, unknown = batch_total_weight_kg(batch, densities)
+    assert total == pytest.approx(1.5)
+    assert unknown == 1


### PR DESCRIPTION
## Summary
- Move cost and weight logic to new `calc` module that takes data dictionaries
- Update Streamlit app to pass session state dictionaries into calculation helpers
- Add unit tests for key cost and weight functions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1650981cc832aaf797b4bd01920e0