### PR TITLE
Reset batch counter and densities on data reset

### DIFF
--- a/app.py
+++ b/app.py
@@ -194,6 +194,20 @@ def ingredient_inline_creator(name_key: str, prefix: str = "") -> str | None:
             st.rerun()
     return None
 
+def reset_session_state() -> None:
+    """Remove persistent data from the session state."""
+    for k in (
+        "ingredients",
+        "recipes",
+        "batches",
+        "new_batch_buffer",
+        "batch_id_counter",
+        "densities",
+        "unlocked",
+    ):
+        if k in st.session_state:
+            del st.session_state[k]
+
 # -----------------------------------------------------------------------------
 # UI — TABS
 # -----------------------------------------------------------------------------
@@ -532,7 +546,5 @@ with tabs[5]:
     st.header("Settings")
     st.caption("Future: export CSV/PDF, backend licenze, densità editabili in UI, tema.")
     if st.button("Reset all data (ingredients, recipes, batches)", key="settings_reset"):
-        for k in ("ingredients", "recipes", "batches", "new_batch_buffer"):
-            if k in st.session_state:
-                del st.session_state[k]
+        reset_session_state()
         st.rerun()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -9,3 +9,23 @@ def test_empty_key_rejected(monkeypatch):
     app = importlib.import_module("app")
     importlib.reload(app)
     assert app.check_key("") is False
+
+
+def test_settings_reset(monkeypatch):
+    monkeypatch.setenv("APP_PASS", "foo")
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    import streamlit as st
+    st.session_state.unlocked = True
+    app = importlib.import_module("app")
+    importlib.reload(app)
+
+    st.session_state.batch_id_counter = 7
+    st.session_state.densities["Water"] = 0.5
+
+    app.reset_session_state()
+
+    st.session_state.unlocked = True
+    importlib.reload(app)
+
+    assert st.session_state.batch_id_counter == 1
+    assert st.session_state.densities == {"Water": 1.0, "Oil EVO": 0.91}


### PR DESCRIPTION
## Summary
- Reset session state including batch ID counter, densities, and unlock flag
- Test that settings reset restores default batch counter and density values

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1651aea0c832a83bb533cb3cdf84b